### PR TITLE
Add missing explicitcad.qrc resource file

### DIFF
--- a/explicitcad.qrc
+++ b/explicitcad.qrc
@@ -1,0 +1,10 @@
+<!DOCTYPE RCC><RCC version="1.0">
+<qresource>
+    <file>images/copy.png</file>
+    <file>images/cut.png</file>
+    <file>images/new.png</file>
+    <file>images/open.png</file>
+    <file>images/paste.png</file>
+    <file>images/save.png</file>
+</qresource>
+</RCC>


### PR DESCRIPTION
qmake complains about a missing explicitcad.qrc (`WARNING: Failure to find: explicitcad.qrc`) and finally compilation fails with:

```
/usr/local/Cellar/qt/5.15.1/bin/rcc -name explicitcad explicitcad.qrc -o qrc_explicitcad.cpp
/usr/local/Cellar/qt/5.15.1/bin/rcc: File does not exist 'explicitcad.qrc'
make: *** [qrc_explicitcad.cpp] Error 1
```

Solution: add explicitcad.qrc with resources contained in the `images/` folder.