### PR TITLE
Fix Qt deprecation warnings

### DIFF
--- a/canvas.cpp
+++ b/canvas.cpp
@@ -246,20 +246,21 @@ void Canvas::wheelEvent(QWheelEvent *event)
 {
     // Find GL position before the zoom operation
     // (to zoom about mouse cursor)
-    auto p = event->pos();
+    auto p = event->position();
     QVector3D v(1 - p.x() / (0.5*width()),
                 p.y() / (0.5*height()) - 1, 0);
     QVector3D a = transform_matrix().inverted() *
                   view_matrix().inverted() * v;
+    const auto angle = event->angleDelta().y();
 
-    if (event->delta() < 0)
+    if (angle < 0)
     {
-        for (int i=0; i > event->delta(); --i)
+        for (int i=0; i > angle; --i)
             zoom /= 1.001;
     }
-    else if (event->delta() > 0)
+    else if (angle > 0)
     {
-        for (int i=0; i < event->delta(); ++i)
+        for (int i=0; i < angle; ++i)
             zoom *= 1.001;
     }
 


### PR DESCRIPTION
Compilation gives 5 deprecation warnings. Fixes are straight-forward.

```
../canvas.cpp:249:21: warning: 'pos' is deprecated: Use position() [-Wdeprecated-declarations]
    auto p = event->pos();
                    ^
/usr/local/Cellar/qt/5.15.1/lib/QtGui.framework/Headers/qevent.h:224:5: note: 'pos' has been explicitly marked deprecated here
    QT_DEPRECATED_VERSION_X_5_15("Use position()")
    ^
/usr/local/Cellar/qt/5.15.1/lib/QtCore.framework/Headers/qglobal.h:374:45: note: expanded from macro 'QT_DEPRECATED_VERSION_X_5_15'
# define QT_DEPRECATED_VERSION_X_5_15(text) QT_DEPRECATED_X(text)
                                            ^
/usr/local/Cellar/qt/5.15.1/lib/QtCore.framework/Headers/qglobal.h:294:33: note: expanded from macro 'QT_DEPRECATED_X'
#  define QT_DEPRECATED_X(text) Q_DECL_DEPRECATED_X(text)
                                ^
/usr/local/Cellar/qt/5.15.1/lib/QtCore.framework/Headers/qcompilerdetection.h:675:55: note: expanded from macro 'Q_DECL_DEPRECATED_X'
#    define Q_DECL_DEPRECATED_X(text) __attribute__ ((__deprecated__(text)))
                                                      ^
../canvas.cpp:255:16: warning: 'delta' is deprecated: Use angleDelta() [-Wdeprecated-declarations]
    if (event->delta() < 0)
               ^
/usr/local/Cellar/qt/5.15.1/lib/QtGui.framework/Headers/qevent.h:218:5: note: 'delta' has been explicitly marked deprecated here
    QT_DEPRECATED_VERSION_X_5_15("Use angleDelta()")
    ^
/usr/local/Cellar/qt/5.15.1/lib/QtCore.framework/Headers/qglobal.h:374:45: note: expanded from macro 'QT_DEPRECATED_VERSION_X_5_15'
# define QT_DEPRECATED_VERSION_X_5_15(text) QT_DEPRECATED_X(text)
                                            ^
/usr/local/Cellar/qt/5.15.1/lib/QtCore.framework/Headers/qglobal.h:294:33: note: expanded from macro 'QT_DEPRECATED_X'
#  define QT_DEPRECATED_X(text) Q_DECL_DEPRECATED_X(text)
                                ^
/usr/local/Cellar/qt/5.15.1/lib/QtCore.framework/Headers/qcompilerdetection.h:675:55: note: expanded from macro 'Q_DECL_DEPRECATED_X'
#    define Q_DECL_DEPRECATED_X(text) __attribute__ ((__deprecated__(text)))
                                                      ^
../canvas.cpp:257:34: warning: 'delta' is deprecated: Use angleDelta() [-Wdeprecated-declarations]
        for (int i=0; i > event->delta(); --i)
                                 ^
/usr/local/Cellar/qt/5.15.1/lib/QtGui.framework/Headers/qevent.h:218:5: note: 'delta' has been explicitly marked deprecated here
    QT_DEPRECATED_VERSION_X_5_15("Use angleDelta()")
    ^
/usr/local/Cellar/qt/5.15.1/lib/QtCore.framework/Headers/qglobal.h:374:45: note: expanded from macro 'QT_DEPRECATED_VERSION_X_5_15'
# define QT_DEPRECATED_VERSION_X_5_15(text) QT_DEPRECATED_X(text)
                                            ^
/usr/local/Cellar/qt/5.15.1/lib/QtCore.framework/Headers/qglobal.h:294:33: note: expanded from macro 'QT_DEPRECATED_X'
#  define QT_DEPRECATED_X(text) Q_DECL_DEPRECATED_X(text)
                                ^
/usr/local/Cellar/qt/5.15.1/lib/QtCore.framework/Headers/qcompilerdetection.h:675:55: note: expanded from macro 'Q_DECL_DEPRECATED_X'
#    define Q_DECL_DEPRECATED_X(text) __attribute__ ((__deprecated__(text)))
                                                      ^
../canvas.cpp:260:21: warning: 'delta' is deprecated: Use angleDelta() [-Wdeprecated-declarations]
    else if (event->delta() > 0)
                    ^
/usr/local/Cellar/qt/5.15.1/lib/QtGui.framework/Headers/qevent.h:218:5: note: 'delta' has been explicitly marked deprecated here
    QT_DEPRECATED_VERSION_X_5_15("Use angleDelta()")
    ^
/usr/local/Cellar/qt/5.15.1/lib/QtCore.framework/Headers/qglobal.h:374:45: note: expanded from macro 'QT_DEPRECATED_VERSION_X_5_15'
# define QT_DEPRECATED_VERSION_X_5_15(text) QT_DEPRECATED_X(text)
                                            ^
/usr/local/Cellar/qt/5.15.1/lib/QtCore.framework/Headers/qglobal.h:294:33: note: expanded from macro 'QT_DEPRECATED_X'
#  define QT_DEPRECATED_X(text) Q_DECL_DEPRECATED_X(text)
                                ^
/usr/local/Cellar/qt/5.15.1/lib/QtCore.framework/Headers/qcompilerdetection.h:675:55: note: expanded from macro 'Q_DECL_DEPRECATED_X'
#    define Q_DECL_DEPRECATED_X(text) __attribute__ ((__deprecated__(text)))
                                                      ^
../canvas.cpp:262:34: warning: 'delta' is deprecated: Use angleDelta() [-Wdeprecated-declarations]
        for (int i=0; i < event->delta(); ++i)
                                 ^
/usr/local/Cellar/qt/5.15.1/lib/QtGui.framework/Headers/qevent.h:218:5: note: 'delta' has been explicitly marked deprecated here
    QT_DEPRECATED_VERSION_X_5_15("Use angleDelta()")
    ^
/usr/local/Cellar/qt/5.15.1/lib/QtCore.framework/Headers/qglobal.h:374:45: note: expanded from macro 'QT_DEPRECATED_VERSION_X_5_15'
# define QT_DEPRECATED_VERSION_X_5_15(text) QT_DEPRECATED_X(text)
                                            ^
/usr/local/Cellar/qt/5.15.1/lib/QtCore.framework/Headers/qglobal.h:294:33: note: expanded from macro 'QT_DEPRECATED_X'
#  define QT_DEPRECATED_X(text) Q_DECL_DEPRECATED_X(text)
                                ^
/usr/local/Cellar/qt/5.15.1/lib/QtCore.framework/Headers/qcompilerdetection.h:675:55: note: expanded from macro 'Q_DECL_DEPRECATED_X'
#    define Q_DECL_DEPRECATED_X(text) __attribute__ ((__deprecated__(text)))
                                                      ^
5 warnings generated.
```