### PR TITLE
add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 build
 *.sw?
-*.s
 Makefile
 .qmake.stash
 *.o

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+Makefile
+.qmake.stash
+*.o
+moc_*
+qrc_*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+build
+*.sw?
+*.s
 Makefile
 .qmake.stash
 *.o


### PR DESCRIPTION
To make `git status` output less cluttered after build.