### PR TITLE
Nix package PoC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,11 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
         qt: ['5.9', '5.10.0', '5.11.3', '5.12.9', '5.13.2', '5.14.2', '5.15.1']
+        build: ['native', 'nix']
+        exclude:
+          - os: windows-latest
+            build: 'nix'
+
     # The CMake configure and build commands are platform agnostic and should work equally
     # well on Windows or Mac.  You can convert this to a matrix build if you need
     # cross-platform coverage.
@@ -21,12 +26,13 @@ jobs:
     steps:
     # Hotfix for fail on macOS until https://github.com/jurplel/install-qt-action/issues/60 is merged
     - name: Hotfix for macOS
-      if: startsWith(runner.os, 'macOS')
+      if: startsWith(runner.os, 'macOS') && matrix.build == 'native'
       run: |
         python3 -m pip install setuptools wheel
         python3 -m pip install py7zr aqtinstall
 
     - name: Install Qt5
+      if: matrix.build == 'native'
       uses: jurplel/install-qt-action@v2
       with:
         version: ${{ matrix.qt }}
@@ -56,9 +62,11 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Create Build Environment
+      if: matrix.build == 'native'
       run: cmake -E make_directory ${{runner.workspace}}/build
 
     - name: Configure CMake
+      if: matrix.build == 'native'
       # Use a bash shell so we can use the same syntax for environment variable
       # access regardless of the host operating system
       shell: bash
@@ -75,6 +83,7 @@ jobs:
         cmake --debug-find $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
 
     - name: Build
+      if: matrix.build == 'native'
       working-directory: ${{runner.workspace}}/build
       shell: bash
       # Execute the build.  You can specify a specific target with "--target <NAME>"
@@ -84,6 +93,16 @@ jobs:
       working-directory: ${{runner.workspace}}/build
       shell: bash
       run: DESTDIR="${{runner.workspace}}/install" cmake --install . --config $BUILD_TYPE
+
+    - name: "Install Nix"
+      if: matrix.build == 'nix'
+      uses: cachix/install-nix-action@v11
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+
+    - name: "Nix build"
+      if: matrix.build == 'nix'
+      run: nix-build
 
 #    - name: Test
 #      working-directory: ${{runner.workspace}}/build

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,3 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.libsForQt5.callPackage ./explicitcad.nix {}

--- a/explicitcad.nix
+++ b/explicitcad.nix
@@ -3,6 +3,7 @@
 , mkDerivation
 , fetchFromGitHub
 , qmake
+, qtbase
 , qscintilla
 , haskellPackages }:
 
@@ -19,6 +20,7 @@ mkDerivation rec {
   #};
 
   buildInputs = [
+    qtbase
     (qscintilla.override { withQt5 = true; })
   ];
 
@@ -27,9 +29,9 @@ mkDerivation rec {
   qtWrapperArgs =
     [ "--prefix" "PATH" ":" (lib.makeBinPath [ haskellPackages.implicit ] ) ];
 
-  installPhase = ''
-    install -d $out/bin
-    install -m755 explicitcad $out/bin/
+  preFixup = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    # wrapQtAppsHook is broken for macOS 😂 - do it manually
+    wrapQtApp $out/bin/explicitcad.app/Contents/MacOS/explicitcad
   '';
 
   meta = with stdenv.lib; {
@@ -37,6 +39,7 @@ mkDerivation rec {
     homepage = "https://github.com/kliment/explicitcad";
     license = licenses.gpl3;
     maintainers = [ maintainers.sorki ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
+    broken = builtins.compareVersions qtbase.version "5.9.0" < 0;
   };
 }

--- a/explicitcad.nix
+++ b/explicitcad.nix
@@ -1,0 +1,42 @@
+{ stdenv
+, lib
+, mkDerivation
+, fetchFromGitHub
+, qmake
+, qscintilla
+, haskellPackages }:
+
+mkDerivation rec {
+  version = "master";
+  pname = "explicitcad";
+
+  src = ./.;
+  #src = fetchFromGitHub {
+  #  owner = "kliment";
+  #  repo = "explicitcad";
+  #  rev = version;
+  #  sha256 = "0w5pidzhpwpggjn5la384fvjzkvprvrnidb06068whci11kgpbp7";
+  #};
+
+  buildInputs = [
+    (qscintilla.override { withQt5 = true; })
+  ];
+
+  nativeBuildInputs = [ qmake ];
+
+  qtWrapperArgs =
+    [ "--prefix" "PATH" ":" (lib.makeBinPath [ haskellPackages.implicit ] ) ];
+
+  installPhase = ''
+    install -d $out/bin
+    install -m755 explicitcad $out/bin/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A graphical user interface for implicitcad";
+    homepage = "https://github.com/kliment/explicitcad";
+    license = licenses.gpl3;
+    maintainers = [ maintainers.sorki ];
+    platforms = platforms.linux;
+  };
+}

--- a/explicitcad.pro
+++ b/explicitcad.pro
@@ -1,6 +1,6 @@
 QT += core gui opengl widgets
-CONFIG      += qscintilla2
-
+CONFIG += qscintilla2
+CONFIG += c++14
 
 #macx {
 #    QMAKE_POST_LINK = install_name_tool -change libqscintilla2_qt$${QT_MAJOR_VERSION}.13.dylib $$[QT_INSTALL_LIBS]/libqscintilla2_qt$${QT_MAJOR_VERSION}.13.dylib $(TARGET)
@@ -12,4 +12,8 @@ RESOURCES    = explicitcad.qrc
 RESOURCES += gl/gl.qrc
 
 
-CONFIG += c++14
+isEmpty(PREFIX) {
+  PREFIX = /usr/local
+}
+target.path = $$PREFIX/bin/
+INSTALLS += target


### PR DESCRIPTION
Allows to build `explicitcad` with Nix using `nix-build`. Afterwards it can be launched using `./result/bin/explicitcad` wrapper, which also sets PATH correctly to contain `extopenscad` binary so stuff just works^TM.

Creating a draft PR so I don't forget about this - let me know when you feel like it's a good time to submit this as a NixOS package, ideally some releases/tags would be cool so I don't have to pick arbitrary commits from master.